### PR TITLE
fix: 作業ディレクトリを `app` 配下とするように修正

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -40,9 +40,11 @@ jobs:
 
       - name: Install dependencies
         run: bun install
+        working-directory: ./app
 
       - name: Build
         run: bun run build
+        working-directory: ./app
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -50,7 +52,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './dist'
+          path: ./app/dist
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
#8 の対応ミスの修正