### PR TITLE
#15: セルをクリックして生死状態を切り替えられるように対応, 次世代判定処理の速度を改善, #17: シャーレ外の門番セルを保持しないように改善

### DIFF
--- a/.github/workflows/run-unit-test.yaml
+++ b/.github/workflows/run-unit-test.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  unit-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -25,15 +25,19 @@ function App() {
     setGeneration((prev) => prev + 1);
   };
 
-  // TODO: filterに余計な時間を要するため、外側の要素を保持しない方法としたい
-  const cells = aliveState
-    .filter((_, i) => !isOutside(i, width + 2, height + 2))
-    .map((alive, i) => {
-      const key = i;
-      return <Cell key={key} alive={Boolean(alive)} />;
-    });
+  const onClickCell = (index: number) => () => {
+    aliveState[index] ^= ALIVE;
+    setAliveState([...aliveState]);
+  };
 
-  // TODO: セルをクリックすることで生死をON/OFFできるようにしたい
+  const cells = aliveState.map((alive, i) => {
+    if (isOutside(i, width + 2, height + 2)) {
+      return null;
+    }
+    const key = i;
+    return <Cell key={key} alive={Boolean(alive)} onClick={onClickCell(key)} />;
+  });
+
   return (
     <>
       <button type="button" onClick={onClick}>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,19 +2,14 @@ import { useState } from "react";
 import "./App.css";
 import { Cell } from "./Cell";
 import { Schale } from "./Schale";
-import { ALIVE, apply, DEAD, isOutside, type aliveState } from "./gol-rule";
+import { ALIVE, apply, DEAD, type aliveState } from "./gol-rule";
 
 function App() {
   const width = 80;
   const height = 80;
   const [aliveState, setAliveState] = useState(
-    [...Array((width + 2) * (height + 2))].map<aliveState>((_, i) =>
-      // TODO: isOutsideを参照しないようにしたい
-      isOutside(i, width + 2, height + 2)
-        ? DEAD
-        : Math.random() >= 0.5
-          ? ALIVE
-          : DEAD,
+    [...Array(width * height)].map<aliveState>(() =>
+      Math.random() >= 0.5 ? ALIVE : DEAD,
     ),
   );
   const [generation, setGeneration] = useState(0);
@@ -31,11 +26,10 @@ function App() {
   };
 
   const cells = aliveState.map((alive, i) => {
-    if (isOutside(i, width + 2, height + 2)) {
-      return null;
-    }
     const key = i;
-    return <Cell key={key} alive={Boolean(alive)} onClick={onClickCell(key)} />;
+    return (
+      <Cell key={key} alive={alive === ALIVE} onClick={onClickCell(key)} />
+    );
   });
 
   return (

--- a/app/src/Cell.tsx
+++ b/app/src/Cell.tsx
@@ -8,18 +8,24 @@ type CellProps = {
   height?: number;
   /** セルの生死状態（true:生, false:死） */
   alive?: boolean;
+  /** セルのクリック時イベントハンドラ */
+  onClick: () => void;
 };
 
 export const Cell: React.FC<CellProps> = ({
   width = 10,
   height = 10,
   alive = false,
+  onClick,
 }) => {
   const cellStyle = css({
     width: width,
     height: height,
     backgroundColor: alive ? "#00ff2a" : "#333333",
     borderColor: "#333333",
+    borderRadius: "0",
+    paddingBlock: "unset",
+    paddingInline: "inherit",
   });
-  return <div css={cellStyle} />;
+  return <button type="button" css={cellStyle} onClick={onClick} />;
 };

--- a/app/src/gol-rule.ts
+++ b/app/src/gol-rule.ts
@@ -8,7 +8,6 @@ export const apply = (
   width: number,
   height: number,
 ) => {
-  // TODO: ビットボードのアルゴリズムで書き換える
   return aliveStates.map<aliveState>((state, index, states) => {
     const widthWithOutside = width + 2;
     const heightWithOutside = height + 2;
@@ -28,28 +27,14 @@ export const apply = (
 
     const sumAliveCells =
       upLeft + up + upRight + left + right + downLeft + down + downRight;
-    if (state) {
-      // 生存
-      if (sumAliveCells === 2 || sumAliveCells === 3) {
-        return ALIVE;
-      }
 
-      // 過疎
-      if (sumAliveCells <= 1) {
-        return DEAD;
-      }
+    // 誕生or生存のパターンに該当すれば次世代は生存
+    // 過疎or過密orそれ以外のパターンであれば次世代は死亡
 
-      // 過密
-      // if (sumAliveCells >= 4)
-      return DEAD;
-    }
-
-    // 誕生
-    if (sumAliveCells === 3) {
-      return ALIVE;
-    }
-
-    return DEAD;
+    // 誕生: 現在の状態=死亡, 近傍の生存セル数=3
+    // 生存: 現在の状態=生存, 近傍の生存セル数=2or3
+    // よって、現在の状態と近傍の生存セル数のORをとった値がちょうど3であれば、次世代は生存となる
+    return (state | sumAliveCells) === 0b0011 ? ALIVE : DEAD;
   });
 };
 

--- a/app/src/gol-rule.ts
+++ b/app/src/gol-rule.ts
@@ -8,10 +8,10 @@ export const apply = (
   width: number,
   height: number,
 ) => {
-  return aliveStates.map<aliveState>((state, index, states) => {
-    const widthWithOutside = width + 2;
-    const heightWithOutside = height + 2;
+  const widthWithOutside = width + 2;
+  const heightWithOutside = height + 2;
 
+  return aliveStates.map<aliveState>((state, index, states) => {
     if (isOutside(index, widthWithOutside, heightWithOutside)) {
       return DEAD;
     }

--- a/app/src/gol-rule.ts
+++ b/app/src/gol-rule.ts
@@ -8,34 +8,38 @@ export const apply = (
   width: number,
   height: number,
 ) => {
+  const nextAliveStates = Array<aliveState>(aliveStates.length).fill(DEAD);
   const widthWithOutside = width + 2;
-  const heightWithOutside = height + 2;
 
-  return aliveStates.map<aliveState>((state, index, states) => {
-    if (isOutside(index, widthWithOutside, heightWithOutside)) {
-      return DEAD;
+  for (let y = 1; y <= height; y++) {
+    for (let x = 1; x <= width; x++) {
+      const offset = 1 + y * widthWithOutside + (x - 1);
+
+      const upLeft = aliveStates[offset - (widthWithOutside + 1)];
+      const up = aliveStates[offset - widthWithOutside];
+      const upRight = aliveStates[offset - (widthWithOutside - 1)];
+      const left = aliveStates[offset - 1];
+      const central = aliveStates[offset];
+      const right = aliveStates[offset + 1];
+      const downLeft = aliveStates[offset + (widthWithOutside - 1)];
+      const down = aliveStates[offset + widthWithOutside];
+      const downRight = aliveStates[offset + (widthWithOutside + 1)];
+
+      const sumAliveCells =
+        upLeft + up + upRight + left + right + downLeft + down + downRight;
+
+      // 誕生or生存のパターンに該当すれば次世代は生存
+      // 過疎or過密orそれ以外のパターンであれば次世代は死亡
+
+      // 誕生: 現在の状態=死亡, 近傍の生存セル数=3
+      // 生存: 現在の状態=生存, 近傍の生存セル数=2or3
+      // よって、現在の状態と近傍の生存セル数のORをとった値がちょうど3であれば、次世代は生存となる
+      nextAliveStates[offset] =
+        (central | sumAliveCells) === 0b0011 ? ALIVE : DEAD;
     }
+  }
 
-    const upLeft = states[index - (widthWithOutside + 1)];
-    const up = states[index - widthWithOutside];
-    const upRight = states[index - (widthWithOutside - 1)];
-    const left = states[index - 1];
-    const right = states[index + 1];
-    const downLeft = states[index + (widthWithOutside - 1)];
-    const down = states[index + widthWithOutside];
-    const downRight = states[index + (widthWithOutside + 1)];
-
-    const sumAliveCells =
-      upLeft + up + upRight + left + right + downLeft + down + downRight;
-
-    // 誕生or生存のパターンに該当すれば次世代は生存
-    // 過疎or過密orそれ以外のパターンであれば次世代は死亡
-
-    // 誕生: 現在の状態=死亡, 近傍の生存セル数=3
-    // 生存: 現在の状態=生存, 近傍の生存セル数=2or3
-    // よって、現在の状態と近傍の生存セル数のORをとった値がちょうど3であれば、次世代は生存となる
-    return (state | sumAliveCells) === 0b0011 ? ALIVE : DEAD;
-  });
+  return nextAliveStates;
 };
 
 export const isOutside = (

--- a/app/src/gol-rule.ts
+++ b/app/src/gol-rule.ts
@@ -8,49 +8,53 @@ export const apply = (
   width: number,
   height: number,
 ) => {
-  const nextAliveStates = Array<aliveState>(aliveStates.length).fill(DEAD);
-  const widthWithOutside = width + 2;
+  const nextAliveStates = Array<aliveState>(aliveStates.length);
 
-  for (let y = 1; y <= height; y++) {
-    for (let x = 1; x <= width; x++) {
-      const offset = 1 + y * widthWithOutside + (x - 1);
+  for (let i = 0; i < width * height; i++) {
+    const _isUpEdge = isUpEdge(i, width);
+    const _isDownEdge = isDownEdge(i, width, height);
+    const _isLeftEdge = isLeftEdge(i, width);
+    const _isRightEdge = isRightEdge(i, width);
 
-      const upLeft = aliveStates[offset - (widthWithOutside + 1)];
-      const up = aliveStates[offset - widthWithOutside];
-      const upRight = aliveStates[offset - (widthWithOutside - 1)];
-      const left = aliveStates[offset - 1];
-      const central = aliveStates[offset];
-      const right = aliveStates[offset + 1];
-      const downLeft = aliveStates[offset + (widthWithOutside - 1)];
-      const down = aliveStates[offset + widthWithOutside];
-      const downRight = aliveStates[offset + (widthWithOutside + 1)];
+    const upLeft =
+      _isUpEdge || _isLeftEdge ? DEAD : aliveStates[i - (width + 1)];
+    const up = _isUpEdge ? DEAD : aliveStates[i - width];
+    const upRight =
+      _isUpEdge || _isRightEdge ? DEAD : aliveStates[i - (width - 1)];
+    const left = _isLeftEdge ? DEAD : aliveStates[i - 1];
+    const central = aliveStates[i];
+    const right = _isRightEdge ? DEAD : aliveStates[i + 1];
+    const downLeft =
+      _isDownEdge || _isLeftEdge ? DEAD : aliveStates[i + (width - 1)];
+    const down = _isDownEdge ? DEAD : aliveStates[i + width];
+    const downRight =
+      _isDownEdge || _isRightEdge ? DEAD : aliveStates[i + (width + 1)];
 
-      const sumAliveCells =
-        upLeft + up + upRight + left + right + downLeft + down + downRight;
+    const sumAliveCells =
+      upLeft + up + upRight + left + right + downLeft + down + downRight;
 
-      // 誕生or生存のパターンに該当すれば次世代は生存
-      // 過疎or過密orそれ以外のパターンであれば次世代は死亡
+    // 誕生or生存のパターンに該当すれば次世代は生存
+    // 過疎or過密orそれ以外のパターンであれば次世代は死亡
 
-      // 誕生: 現在の状態=死亡, 近傍の生存セル数=3
-      // 生存: 現在の状態=生存, 近傍の生存セル数=2or3
-      // よって、現在の状態と近傍の生存セル数のORをとった値がちょうど3であれば、次世代は生存となる
-      nextAliveStates[offset] =
-        (central | sumAliveCells) === 0b0011 ? ALIVE : DEAD;
-    }
+    // 誕生: 現在の状態=死亡, 近傍の生存セル数=3
+    // 生存: 現在の状態=生存, 近傍の生存セル数=2or3
+    // よって、現在の状態と近傍の生存セル数のORをとった値がちょうど3であれば、次世代は生存となる
+    nextAliveStates[i] = (central | sumAliveCells) === 0b0011 ? ALIVE : DEAD;
   }
 
   return nextAliveStates;
 };
 
-export const isOutside = (
-  index: number,
-  widthWithOutside: number,
-  heightWithOutside: number,
-) => {
-  return (
-    /* 上端 */ index < widthWithOutside ||
-    /* 下端 */ widthWithOutside * (heightWithOutside - 1) <= index ||
-    /* 左端 */ index % widthWithOutside === 0 ||
-    /* 右端 */ index % widthWithOutside === widthWithOutside - 1
-  );
-};
+// 上端か否か
+const isUpEdge = (index: number, width: number) => index < width;
+
+// 下端か否か
+const isDownEdge = (index: number, width: number, height: number) =>
+  width * (height - 1) <= index;
+
+// 左端か否か
+const isLeftEdge = (index: number, width: number) => index % width === 0;
+
+// 右端か否か
+const isRightEdge = (index: number, width: number) =>
+  index % width === width - 1;

--- a/app/tests/gol-rule.test.ts
+++ b/app/tests/gol-rule.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { ALIVE as A, apply, DEAD as D } from "../src/gol-rule";
+import { ALIVE as A, apply, DEAD as D, isOutside } from "../src/gol-rule";
 
 test("死亡セルに隣接する生存セルが3つあれば、次世代が誕生（生存へ変化）すること", () => {
   // Arrange
@@ -137,4 +137,24 @@ test("2世代の経過後、ブリンカーは元の状態に戻ること", () =
 
   // Assert
   expect(actual).toEqual(expectedAfterTwoGenerations);
+});
+
+test("apply()実行時間の計測", () => {
+  // 計測方法の参考: https://qiita.com/bmjuggler/items/7b7673433a744b9ac87d
+
+  const width = 1280;
+  const height = 800;
+  const testData = [...Array((width + 2) * (height + 2))].map((_, i) =>
+    isOutside(i, width + 2, height + 2) ? D : Math.random() >= 0.5 ? A : D,
+  );
+
+  const start = process.hrtime();
+
+  apply(testData, width, height);
+
+  const end = process.hrtime(start);
+  const time = end[0] * 1000 + end[1] / 1e6;
+
+  console.debug(`Execute time is ${time.toFixed(5)} ms`);
+  expect().pass();
 });

--- a/app/tests/gol-rule.test.ts
+++ b/app/tests/gol-rule.test.ts
@@ -1,24 +1,20 @@
 import { expect, test } from "bun:test";
-import { ALIVE as A, apply, DEAD as D, isOutside } from "../src/gol-rule";
+import { ALIVE as A, apply, DEAD as D } from "../src/gol-rule";
 
 test("死亡セルに隣接する生存セルが3つあれば、次世代が誕生（生存へ変化）すること", () => {
   // Arrange
-  // 3x3 + 外側
+  // 3x3
   // biome-ignore format: the array should not be formatted
   const testData = [
-    D, D, D, D, D,
-    D, A, A, D, D,
-    D, A, D, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    A, A, D,
+    A, D, D,
+    D, D, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expected = [
-    D, D, D, D, D,
-    D, A, A, D, D,
-    D, A, A, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    A, A, D,
+    A, A, D,
+    D, D, D,
   ];
 
   // Act
@@ -30,24 +26,20 @@ test("死亡セルに隣接する生存セルが3つあれば、次世代が誕�
 
 test("生存セルに隣接する生存セルが2つか3つならば、次世代でも生存すること", () => {
   // Arrange
-  // 4x4 + 外側
+  // 4x4
   // biome-ignore format: the array should not be formatted
   const testData = [
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
-    D, D, A, A, D, D,
-    D, D, A, A, D, D,
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
+    D, D, D, D,
+    D, A, A, D,
+    D, A, A, D,
+    D, D, D, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expected = [
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
-    D, D, A, A, D, D,
-    D, D, A, A, D, D,
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
+    D, D, D, D,
+    D, A, A, D,
+    D, A, A, D,
+    D, D, D, D,
   ];
 
   // Act
@@ -59,22 +51,18 @@ test("生存セルに隣接する生存セルが2つか3つならば、次世代
 
 test("生存セルに隣接する生存セルが1つ以下ならば、次世代では過疎により死亡すること", () => {
   // Arrange
-  // 3x3 + 外側
+  // 3x3
   // biome-ignore format: the array should not be formatted
   const testData = [
-    D, D, D, D, D,
-    D, D, D, D, D,
-    D, D, A, A, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    D, D, D,
+    D, A, A,
+    D, D, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expected = [
-    D, D, D, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    D, D, D,
+    D, D, D,
+    D, D, D,
   ];
 
   // Act
@@ -86,22 +74,18 @@ test("生存セルに隣接する生存セルが1つ以下ならば、次世代�
 
 test("生存セルに隣接する生存セルが4つ以上ならば、次世代では過密により死亡すること", () => {
   // Arrange
-  // 3x3 + 外側
+  // 3x3
   // biome-ignore format: the array should not be formatted
   const testData = [
-    D, D, D, D, D,
-    D, A, A, A, D,
-    D, A, A, D, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    A, A, A,
+    A, A, D,
+    D, D, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expected = [
-    D, D, D, D, D,
-    D, A, D, A, D,
-    D, A, D, A, D,
-    D, D, D, D, D,
-    D, D, D, D, D,
+    A, D, A,
+    A, D, A,
+    D, D, D,
   ];
 
   // Act
@@ -113,22 +97,18 @@ test("生存セルに隣接する生存セルが4つ以上ならば、次世代�
 
 test("2世代の経過後、ブリンカーは元の状態に戻ること", () => {
   // Arrange
-  // 3x3 + 外側
+  // 3x3
   // biome-ignore format: the array should not be formatted
   const blinker = [
-    D, D, D, D, D,
-    D, D, A, D, D,
-    D, D, A, D, D,
-    D, D, A, D, D,
-    D, D, D, D, D,
+    D, A, D,
+    D, A, D,
+    D, A, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expectedAfterTwoGenerations = [
-    D, D, D, D, D,
-    D, D, A, D, D,
-    D, D, A, D, D,
-    D, D, A, D, D,
-    D, D, D, D, D,
+    D, A, D,
+    D, A, D,
+    D, A, D,
   ];
   const nextGeneration = apply(blinker, 3, 3);
 
@@ -143,24 +123,20 @@ test("4世代の経過後、グライダーは右下1セル分移動している
   // Arrange
   const width = 4;
   const height = 4;
-  // 4x4 + 外側
+  // 4x4
   // biome-ignore format: the array should not be formatted
   const generation1 = [
-    D, D, D, D, D, D,
-    D, D, A, D, D, D,
-    D, D, D, A, D, D,
-    D, A, A, A, D, D,
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
+    D, A, D, D,
+    D, D, A, D,
+    A, A, A, D,
+    D, D, D, D,
   ];
   // biome-ignore format: the array should not be formatted
   const expectedGeneration5 = [
-    D, D, D, D, D, D,
-    D, D, D, D, D, D,
-    D, D, D, A, D, D,
-    D, D, D, D, A, D,
-    D, D, A, A, A, D,
-    D, D, D, D, D, D,
+    D, D, D, D,
+    D, D, A, D,
+    D, D, D, A,
+    D, A, A, A,
   ];
   const generation2 = apply(generation1, width, height);
   const generation3 = apply(generation2, width, height);
@@ -178,8 +154,8 @@ test("apply()実行時間の計測", () => {
 
   const width = 1280;
   const height = 800;
-  const testData = [...Array((width + 2) * (height + 2))].map((_, i) =>
-    isOutside(i, width + 2, height + 2) ? D : Math.random() >= 0.5 ? A : D,
+  const testData = [...Array(width * height)].map(() =>
+    Math.random() >= 0.5 ? A : D,
   );
 
   const start = process.hrtime();

--- a/app/tests/gol-rule.test.ts
+++ b/app/tests/gol-rule.test.ts
@@ -139,6 +139,40 @@ test("2世代の経過後、ブリンカーは元の状態に戻ること", () =
   expect(actual).toEqual(expectedAfterTwoGenerations);
 });
 
+test("4世代の経過後、グライダーは右下1セル分移動していること", () => {
+  // Arrange
+  const width = 4;
+  const height = 4;
+  // 4x4 + 外側
+  // biome-ignore format: the array should not be formatted
+  const generation1 = [
+    D, D, D, D, D, D,
+    D, D, A, D, D, D,
+    D, D, D, A, D, D,
+    D, A, A, A, D, D,
+    D, D, D, D, D, D,
+    D, D, D, D, D, D,
+  ];
+  // biome-ignore format: the array should not be formatted
+  const expectedGeneration5 = [
+    D, D, D, D, D, D,
+    D, D, D, D, D, D,
+    D, D, D, A, D, D,
+    D, D, D, D, A, D,
+    D, D, A, A, A, D,
+    D, D, D, D, D, D,
+  ];
+  const generation2 = apply(generation1, width, height);
+  const generation3 = apply(generation2, width, height);
+  const generation4 = apply(generation3, width, height);
+
+  // Act
+  const actualGeneration5 = apply(generation4, width, height);
+
+  // Assert
+  expect(actualGeneration5).toEqual(expectedGeneration5);
+});
+
 test("apply()実行時間の計測", () => {
   // 計測方法の参考: https://qiita.com/bmjuggler/items/7b7673433a744b9ac87d
 


### PR DESCRIPTION
#15
- セルに `onClick` イベント追加
- `div` を `button` 要素へ変更（Biomeでエラーが出た＋`div`だとクリッカブルなことが判別できないため）

次世代判定処理の速度改善
- Chat-GPT曰はく「`map()` よりも `for` 文の方が速い」らしいので、書き換えた
- ら、確かに速度が改善したので採用
  - before: 約25ms https://github.com/ytak-sagit/game-of-life-react/actions/runs/10654129122/job/29530055954
  - after: 約16ms https://github.com/ytak-sagit/game-of-life-react/actions/runs/10721585935/job/29730438571
- 他、近傍8セルから次世代の状態を判定する処理を、一つに集約
  - ビット演算を使うことで、誕生/生存/過疎/過密の4パターン別に条件判定をせずに良くなった

#17 
- 全セルに `onClick` を追加したからなのか、対応以前よりも重くなったような気がした
- ので、セル配列にてシャーレ外の門番セルを保持しない対応も併せて行った
- この対応で次世代判定処理が若干遅くなったが、改善前と遜色ない程度
  - after: 約21ms https://github.com/ytak-sagit/game-of-life-react/actions/runs/10722527436/job/29733655268
- テストコードも併せて修正
