### PR TITLE
#27: 世代数ならびに全セルの状態を`DEAD`へリセットするボタンを追加

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,10 +32,18 @@ function App() {
     );
   });
 
+  const onReset = () => {
+    setAliveState(Array<aliveState>(aliveState.length).fill(DEAD));
+    setGeneration(0);
+  };
+
   return (
     <>
       <button type="button" onClick={onClick}>
         Next generation
+      </button>
+      <button type="reset" onClick={onReset}>
+        Reset
       </button>
       <p>Generaion is #{generation}</p>
       <Schale width={width * 10} height={height * 10}>


### PR DESCRIPTION
issues: #27 
- issues ではボタンラベルを「クリア」と想定していたが、「リセット」へ変更した
  - 特にこだわりはない
- 世代数もゼロへリセットする