### PR TITLE
#36: レスポンシブデザイン対応

### DIFF
--- a/app/src/components/flex-list/index.tsx
+++ b/app/src/components/flex-list/index.tsx
@@ -18,6 +18,8 @@ export const FlexList: React.FC<FlexListProps> = ({
     justifyContent: "center",
     columnGap: `${gapSizePx}px`,
     listStyle: "none",
+    paddingInlineStart: "unset",
+    marginBlock: "unset",
   });
 
   return (

--- a/app/src/config/environments.ts
+++ b/app/src/config/environments.ts
@@ -6,8 +6,20 @@ export const CELL_WIDTH = 10;
 /** セルの縦幅 */
 export const CELL_HEIGHT = 10;
 
+/** シャーレ1行あたりのセル配置件数 既定値 */
+const DEFAULT_NUMBER_OF_CELLS_PER_ROW = 128;
+
 /** シャーレ1行あたりのセル配置件数 */
-export const NUMBER_OF_CELLS_PER_ROW = 80;
+export const NUMBER_OF_CELLS_PER_ROW = Math.min(
+  DEFAULT_NUMBER_OF_CELLS_PER_ROW,
+  Math.trunc(window.innerWidth / CELL_WIDTH) - 4,
+);
+
+/** シャーレ1列あたりのセル配置件数 既定値 */
+const DEFAULT_NUMBER_OF_CELLS_PER_COL = 98;
 
 /** シャーレ1列あたりのセル配置件数 */
-export const NUMBER_OF_CELLS_PER_COL = 80;
+export const NUMBER_OF_CELLS_PER_COL = Math.min(
+  DEFAULT_NUMBER_OF_CELLS_PER_COL,
+  Math.trunc(window.innerHeight / CELL_HEIGHT) - 14,
+);

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -16,6 +16,7 @@
 body {
   margin: 0;
   display: flex;
+  justify-content: center;
   place-items: center;
   min-width: 320px;
   min-height: 100vh;

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -46,8 +46,6 @@ button[aria-disabled=true] {
 
 #root {
   max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
   text-align: center;
 }
 


### PR DESCRIPTION
- 動的判定すると描画がかなり遅くなるため、初回ローディング時のみ画面サイズを判定する
  - スマホ・タブレットの場合はブラウザサイズを初回から変更することはない（できない）ため問題ない
  - PCはブラウザサイズを初回から変更することが普通にあり得るが、制限とする
- ボタン、フォントのサイズはひとまずそのまま（変更なし）
- セルのサイズもそのまま（変更なし）
  - 実機検証してみて、問題ありそうなら改善する
