### PR TITLE
#50: スマホ画面でもレイアウト崩れが生じないように修正

### DIFF
--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -55,26 +55,30 @@ export const App = () => {
 
   return (
     <main>
-      <FlexList>
-        <button type="button" onClick={onClickStartOrStop}>
-          {isPolling ? "Stop" : "Start"}
-        </button>
-        <button type="button" onClick={onClickNext} disabled={isPolling}>
-          Next
-        </button>
-        <button type="reset" onClick={onReset} disabled={isPolling}>
-          Reset
-        </button>
-        <PatternPulldownList onChange={onChange} disabled={isPolling} />
+      <FlexList flexDirection="column">
+        <FlexList>
+          <button type="button" onClick={onClickStartOrStop}>
+            {isPolling ? "Stop" : "Start"}
+          </button>
+          <button type="button" onClick={onClickNext} disabled={isPolling}>
+            Next
+          </button>
+          <button type="reset" onClick={onReset} disabled={isPolling}>
+            Reset
+          </button>
+        </FlexList>
+        <FlexList>
+          <Generation value={generation} />
+          <PatternPulldownList onChange={onChange} disabled={isPolling} />
+        </FlexList>
+        <Schale
+          cellWidth={CELL_WIDTH}
+          maxWidth={CELL_WIDTH * NUMBER_OF_CELLS_PER_ROW}
+          maxHeight={CELL_HEIGHT * NUMBER_OF_CELLS_PER_COL}
+        >
+          {cells}
+        </Schale>
       </FlexList>
-      <Generation value={generation} />
-      <Schale
-        cellWidth={CELL_WIDTH}
-        maxWidth={CELL_WIDTH * NUMBER_OF_CELLS_PER_ROW}
-        maxHeight={CELL_HEIGHT * NUMBER_OF_CELLS_PER_COL}
-      >
-        {cells}
-      </Schale>
     </main>
   );
 };

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -56,7 +56,7 @@ export const App = () => {
   return (
     <main>
       <FlexList flexDirection="column">
-        <FlexList>
+        <FlexList flexDirection="row">
           <button type="button" onClick={onClickStartOrStop}>
             {isPolling ? "Stop" : "Start"}
           </button>
@@ -67,7 +67,7 @@ export const App = () => {
             Reset
           </button>
         </FlexList>
-        <FlexList>
+        <FlexList flexDirection="row">
           <Generation value={generation} />
           <PatternPulldownList onChange={onChange} disabled={isPolling} />
         </FlexList>

--- a/app/src/components/flex-list/index.tsx
+++ b/app/src/components/flex-list/index.tsx
@@ -3,6 +3,8 @@ import { css } from "@emotion/react";
 import type { ReactElement } from "react";
 
 type FlexListProps = {
+  /** 子コンポーネントの並びの方向("column":縦, "row":横) */
+  flexDirection?: "column" | "row";
   /** 子コンポーネント間の余白サイズ(pixel) */
   gapSizePx?: number;
   /** 子コンポーネント(複数指定が必須) */
@@ -10,12 +12,14 @@ type FlexListProps = {
 };
 
 export const FlexList: React.FC<FlexListProps> = ({
+  flexDirection = "row",
   gapSizePx = 12,
   children,
 }) => {
   const ulStyle = css({
     display: "flex",
     justifyContent: "center",
+    flexDirection,
     columnGap: `${gapSizePx}px`,
     listStyle: "none",
     paddingInlineStart: "unset",

--- a/app/src/components/flex-list/index.tsx
+++ b/app/src/components/flex-list/index.tsx
@@ -26,12 +26,18 @@ export const FlexList: React.FC<FlexListProps> = ({
     paddingInlineStart: "unset",
     marginBlock: "unset",
   });
+  const liStyle = css({
+    marginTop: "auto",
+    marginBottom: "auto",
+  });
 
   return (
     <ul css={ulStyle}>
       {children.map((child, index) => (
         // biome-ignore lint: safe map index of array to key because static
-        <li key={index}>{child}</li>
+        <li key={index} css={liStyle}>
+          {child}
+        </li>
       ))}
     </ul>
   );

--- a/app/src/components/flex-list/index.tsx
+++ b/app/src/components/flex-list/index.tsx
@@ -20,6 +20,7 @@ export const FlexList: React.FC<FlexListProps> = ({
     display: "flex",
     justifyContent: "center",
     flexDirection,
+    rowGap: `${gapSizePx}px`,
     columnGap: `${gapSizePx}px`,
     listStyle: "none",
     paddingInlineStart: "unset",

--- a/app/src/components/flex-list/index.tsx
+++ b/app/src/components/flex-list/index.tsx
@@ -4,7 +4,7 @@ import type { ReactElement } from "react";
 
 type FlexListProps = {
   /** 子コンポーネントの並びの方向("column":縦, "row":横) */
-  flexDirection?: "column" | "row";
+  flexDirection: "column" | "row";
   /** 子コンポーネント間の余白サイズ(pixel) */
   gapSizePx?: number;
   /** 子コンポーネント(複数指定が必須) */
@@ -12,7 +12,7 @@ type FlexListProps = {
 };
 
 export const FlexList: React.FC<FlexListProps> = ({
-  flexDirection = "row",
+  flexDirection,
   gapSizePx = 12,
   children,
 }) => {

--- a/app/src/features/generation/index.tsx
+++ b/app/src/features/generation/index.tsx
@@ -4,5 +4,5 @@ type GenerationProps = {
 };
 
 export const Generation: React.FC<GenerationProps> = ({ value }) => {
-  return <p>Generation is #{value}</p>;
+  return <span>Generation is #{value}</span>;
 };

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -2,6 +2,7 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  font-size: 0.875em;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);


### PR DESCRIPTION
issues: #50
- パターン選択リストを世代数の直後に配置するよう変更
- 上記に伴い、マージン等を最適化
- フォントサイズは小さめに最適化