### PR TITLE
fix: OWASP ZAPスキャン用ワークフローの`docker_name`指定を削除

### DIFF
--- a/.github/workflows/owasp-zap-scan.yaml
+++ b/.github/workflows/owasp-zap-scan.yaml
@@ -26,5 +26,4 @@ jobs:
         with:
           target: ${{ inputs.target-url }}
           token: ${{ secrets.token }}
-          docker_name: 'owasp/zap2docker-stable'
           cmd_options: '-a'


### PR DESCRIPTION
スキャン実行時にエラーが出ていたためその修正
- https://github.com/ytak-sagit/game-of-life-react/actions/runs/11763242155/job/32766990139