### PR TITLE
fix: OWASP ZAPスキャン用ジョブに`issues`作成用の権限を追加

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -74,7 +74,8 @@ jobs:
     needs: deploy
     if: ${{ success() }}
 
-    permissions: {}
+    permissions:
+      issues: write
 
     uses: ./.github/workflows/owasp-zap-scan.yaml
     with:

--- a/.github/workflows/owasp-zap-scan.yaml
+++ b/.github/workflows/owasp-zap-scan.yaml
@@ -14,11 +14,12 @@ on:
         required: true
         description: GitHub トークン
 
-permissions: {}
-
 jobs:
   scan:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
 
     steps:
       - name: Owasp Zap Baseline Scan


### PR DESCRIPTION
スキャンレポートを issues として作成することが可能だが、その作成権限がなかったため付与
- https://github.com/ytak-sagit/game-of-life-react/actions/runs/11763343181/job/32767209513

```bash
POST /repos/ytak-sagit/game-of-life-react/issues - 403 with id 6040:1876:1D1FDBE:387A000:67306511 in 78ms
Error: Resource not accessible by integration - https://docs.github.com/rest/issues/issues#create-an-issue
```

※ issues 作成を行うか否かは、`allow_issue_writing` パラメータで指定可能
- https://github.com/zaproxy/action-baseline/tree/v0.13.0/?tab=readme-ov-file#allow_issue_writing