### PR TITLE
fix: ブラウザのウィンドウリサイズ時にスクロール表示領域サイズも動的に変わるよう修正

### DIFF
--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -6,8 +6,6 @@ import {
   CELL_WIDTH,
   NUMBER_OF_CELLS_PER_COL,
   NUMBER_OF_CELLS_PER_ROW,
-  SCROLLABLE_AREA_HEIGHT,
-  SCROLLABLE_AREA_WIDTH,
 } from "~/config/environments";
 import { Cell } from "~/features/cell";
 import { Generation } from "~/features/generation";
@@ -74,10 +72,7 @@ export const App = () => {
           <Generation value={generation} />
           <PatternPulldownList onChange={onChange} disabled={isPolling} />
         </FlexList>
-        <ScrollableView
-          width={SCROLLABLE_AREA_WIDTH}
-          height={SCROLLABLE_AREA_HEIGHT}
-        >
+        <ScrollableView>
           <Schale
             cellWidth={CELL_WIDTH}
             maxWidth={CELL_WIDTH * NUMBER_OF_CELLS_PER_ROW}

--- a/app/src/app/index.tsx
+++ b/app/src/app/index.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from "react";
 import { FlexList } from "~/components/flex-list";
-import { ScrollableArea } from "~/components/scrollable-area";
+import { ScrollableView } from "~/components/scrollable-view";
 import {
   CELL_HEIGHT,
   CELL_WIDTH,
@@ -74,7 +74,7 @@ export const App = () => {
           <Generation value={generation} />
           <PatternPulldownList onChange={onChange} disabled={isPolling} />
         </FlexList>
-        <ScrollableArea
+        <ScrollableView
           width={SCROLLABLE_AREA_WIDTH}
           height={SCROLLABLE_AREA_HEIGHT}
         >
@@ -85,7 +85,7 @@ export const App = () => {
           >
             {cells}
           </Schale>
-        </ScrollableArea>
+        </ScrollableView>
       </FlexList>
     </main>
   );

--- a/app/src/components/scrollable-view/index.tsx
+++ b/app/src/components/scrollable-view/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
 
-type ScrollableAreaProps = {
+type ScrollableViewProps = {
   /**
    * スクロール可能領域の横幅(pixel)
    * @description schale の max-width より小さい値を指定する
@@ -16,7 +16,7 @@ type ScrollableAreaProps = {
   children: React.ReactNode;
 };
 
-export const ScrollableArea: React.FC<ScrollableAreaProps> = ({
+export const ScrollableView: React.FC<ScrollableViewProps> = ({
   width,
   height,
   children,

--- a/app/src/components/scrollable-view/index.tsx
+++ b/app/src/components/scrollable-view/index.tsx
@@ -1,26 +1,14 @@
 /** @jsxImportSource @emotion/react */
 import { css } from "@emotion/react";
+import { useScrollableViewSize } from "~/hooks/use-scrollable-view-size";
 
 type ScrollableViewProps = {
-  /**
-   * スクロール可能領域の横幅(pixel)
-   * @description schale の max-width より小さい値を指定する
-   */
-  width: number;
-  /**
-   * スクロール可能領域の縦幅(pixel)
-   * @description schale の max-height より小さい値を指定する
-   */
-  height: number;
   /** スクロール可能領域に表示する子要素 */
   children: React.ReactNode;
 };
 
-export const ScrollableView: React.FC<ScrollableViewProps> = ({
-  width,
-  height,
-  children,
-}) => {
+export const ScrollableView: React.FC<ScrollableViewProps> = ({ children }) => {
+  const { width, height } = useScrollableViewSize();
   const style = css({
     // NOTE: display: "block" だと幅が子要素へ伝搬してしまうため、"flex" としている
     display: "flex",

--- a/app/src/config/environments.ts
+++ b/app/src/config/environments.ts
@@ -11,21 +11,3 @@ export const NUMBER_OF_CELLS_PER_ROW = 128;
 
 /** シャーレ1列あたりのセル配置件数 */
 export const NUMBER_OF_CELLS_PER_COL = 128;
-
-/** スクロール可能領域の横幅 */
-export const SCROLLABLE_AREA_WIDTH =
-  Math.min(
-    NUMBER_OF_CELLS_PER_ROW,
-    Math.trunc(window.innerWidth / CELL_WIDTH) - 4,
-  ) *
-    CELL_WIDTH +
-  6;
-
-/** スクロール可能領域の縦幅 */
-export const SCROLLABLE_AREA_HEIGHT =
-  Math.min(
-    NUMBER_OF_CELLS_PER_COL,
-    Math.trunc(window.innerHeight / CELL_HEIGHT) - 14,
-  ) *
-    CELL_HEIGHT +
-  6;

--- a/app/src/hooks/use-scrollable-view-size.ts
+++ b/app/src/hooks/use-scrollable-view-size.ts
@@ -1,0 +1,43 @@
+import {
+  CELL_HEIGHT,
+  CELL_WIDTH,
+  NUMBER_OF_CELLS_PER_COL,
+  NUMBER_OF_CELLS_PER_ROW,
+} from "~/config/environments";
+import { useWindowSize } from "./use-window-size";
+
+type ScrollableViewSize = {
+  /**
+   * スクロール可能領域の横幅(pixel)
+   * @description schale の max-width 以下の値を想定
+   */
+  width: number;
+  /**
+   * スクロール可能領域の縦幅(pixel)
+   * @description schale の max-height 以下の値を想定
+   */
+  height: number;
+};
+
+export const useScrollableViewSize: () => ScrollableViewSize = () => {
+  const { windowWidth, windowHeight } = useWindowSize();
+  return {
+    width: scrollableWidth(windowWidth),
+    height: scrollableHeight(windowHeight),
+  };
+};
+
+/** スクロール可能領域の横幅 */
+const scrollableWidth = (windowWidth: number) =>
+  Math.min(NUMBER_OF_CELLS_PER_ROW, Math.trunc(windowWidth / CELL_WIDTH) - 4) *
+    CELL_WIDTH +
+  6;
+
+/** スクロール可能領域の縦幅 */
+const scrollableHeight = (windowHeight: number) =>
+  Math.min(
+    NUMBER_OF_CELLS_PER_COL,
+    Math.trunc(windowHeight / CELL_HEIGHT) - 14,
+  ) *
+    CELL_HEIGHT +
+  6;

--- a/app/src/hooks/use-window-size.ts
+++ b/app/src/hooks/use-window-size.ts
@@ -1,0 +1,29 @@
+/**
+ * 以下を参考に実装:
+ * https://zenn.dev/ncdc/articles/react_window_size_subscription
+ */
+
+import { useSyncExternalStore } from "react";
+
+type WindowSize = {
+  windowWidth: number;
+  windowHeight: number;
+};
+
+const getWindowWidth = () => window.innerWidth;
+
+const getWindowHeight = () => window.innerHeight;
+
+const subscribeWindowSizeChange = (listener: () => void) => {
+  window.addEventListener("resize", listener);
+  return () => window.removeEventListener("resize", listener);
+};
+
+export const useWindowSize = (): WindowSize => {
+  const width = useSyncExternalStore(subscribeWindowSizeChange, getWindowWidth);
+  const height = useSyncExternalStore(
+    subscribeWindowSizeChange,
+    getWindowHeight,
+  );
+  return { windowWidth: width, windowHeight: height };
+};


### PR DESCRIPTION
- ブラウザのウィンドウリサイズ時に、シャーレの表示領域が初期表示時から変わらなかった
- スクロール可能領域の `width`, `height` を固定値としていたのが原因
- リサイズに応じて、表示領域も動的に変更し、スクロールできる範囲も変動するように修正