### PR TITLE
#65: devcontainer内でGit Graphを操作できるように対応

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "../compose.yaml"
   ],
   "service": "app",
-  "workspaceFolder": "/app",
+  "workspaceFolder": "/workspace/app",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   ],
   "service": "app",
   "workspaceFolder": "/workspace/app",
+  "initializeCommand": "mkdir -p app",
   "postAttachCommand": "git config --global --add safe.directory /workspace",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   ],
   "service": "app",
   "workspaceFolder": "/workspace/app",
+  "postAttachCommand": "git config --global --add safe.directory /workspace",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
           // VSCode の organizeImports 設定を追加しておく
           "source.organizeImports": "explicit"
         },
-        "editor.defaultFormatter": "biomejs.biome"
+        "editor.defaultFormatter": "biomejs.biome",
+        "git.openRepositoryInParentFolders": "always"
       }
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "biomejs.biome"
+        "biomejs.biome",
+        "mhutchie.git-graph"
       ],
       "settings": {
         "files.autoSave": "off",

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 ARG USERNAME=vscode
 USER ${USERNAME}
 
-WORKDIR /app
+WORKDIR /workspace/app
 
 RUN mkdir node_modules
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN set -x \
 RUN set -x \
     && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr bash
 
+# git
+RUN set -x \
+    && apt install -y git \
+    && apt clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG USERNAME=vscode
 USER ${USERNAME}
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,3 +19,8 @@ services:
 
 volumes:
   node_modules:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD}/app/node_modules
+      o: bind

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,10 +4,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    working_dir: /app
+    working_dir: /workspace/app
     volumes:
-      - ./app:/app
-      - node_modules:/app/node_modules
+      - .:/workspace
+      - node_modules:/workspace/app/node_modules
     # NOTE:
     # 以下の指定だと、0.0.0.0:5173 へ転送される。
     # localhost:5173 へ転送されてほしいため、コメントアウトした。


### PR DESCRIPTION
合わせて以下も対応
- gitコマンドを devcontainer へインストール
- `.git` ディレクトリが必要なため、全ファイルを `/workspace` 以下へ複写するように修正
  - 併せて、`WORKDIR` も `/app` から `/workspace/app` へ変更
- ホスト側にあらかじめ `app` ディレクトリがないと devcontainer 作成に失敗するため、`mkdir` コマンドを追加
- Local Volumesへ変更