### PR TITLE
fix: Codespaces起動時にボリュームマウントに失敗していたため、ローカルボリュームを使用しないように変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   ],
   "service": "app",
   "workspaceFolder": "/workspace/app",
-  "initializeCommand": "mkdir -p app/node_modules",
+  "initializeCommand": "mkdir -p app",
   "postAttachCommand": "git config --global --add safe.directory /workspace",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   ],
   "service": "app",
   "workspaceFolder": "/workspace/app",
-  "initializeCommand": "mkdir -p app",
+  "initializeCommand": "mkdir -p app/node_modules",
   "postAttachCommand": "git config --global --add safe.directory /workspace",
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ USER ${USERNAME}
 
 WORKDIR /workspace/app
 
+RUN mkdir node_modules
+
 # コンテナ起動時のデフォルトコマンドを設定
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,6 @@ RUN set -x \
 RUN set -x \
     && curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr bash
 
-# git
-RUN set -x \
-    && apt install -y git \
-    && apt clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
 ARG USERNAME=vscode
 USER ${USERNAME}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,5 @@ USER ${USERNAME}
 
 WORKDIR /workspace/app
 
-RUN mkdir node_modules
-
 # コンテナ起動時のデフォルトコマンドを設定
 CMD ["/bin/bash"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,8 +19,3 @@ services:
 
 volumes:
   node_modules:
-    driver: local
-    driver_opts:
-      type: none
-      device: ${PWD}/app/node_modules
-      o: bind


### PR DESCRIPTION
- `failed to mount local volume` とエラー発生して Codespaces が起動できなかったため修正
- ローカルボリュームだと事前に `app/node_modules` ディレクトリが存在している必要がある
- ~~そのため、コンテナ作成前にまずホスト側に `app/node_modules` ディレクトリを作成する工程を追加~~